### PR TITLE
Bug with nested forms and multiple templates on the same page

### DIFF
--- a/app/views/uploader/default/_container.html.erb
+++ b/app/views/uploader/default/_container.html.erb
@@ -1,9 +1,9 @@
 <%= content_tag(:div, :id => field.id, :class => "uploader-dnd-area") do -%>
   <%= hidden_field(field.object_name, :fileupload_guid, :object => field.object) if field.object.new_record? %>
-  
+
   <div class="uploader-files"></div>
-  
-	<div class="uploader-dnd-hints">  
+
+	<div class="uploader-dnd-hints">
 	  <span class="uploader-button gray fileinput-button">
       <span><%= I18n.t('uploader.button') %></span>
       <%= fields_for field.object do |f| -%>
@@ -12,21 +12,21 @@
 	      <% end -%>
 	    <% end -%>
     </span>
-    
+
 	  <div class="uploader-dnd-hint">
 		  <%= I18n.t('uploader.or') %><span><%= I18n.t('uploader.drop') %></span>
 	  </div>
 	</div>
-	
+
 	<%= render :partial => "uploader/#{field.theme}/upload", :locals => {:field => field} %>
   <%= render :partial => "uploader/#{field.theme}/download", :locals => {:field => field} %>
   <%= render :partial => "uploader/#{field.theme}/sortable", :locals => {:field => field} if field.sortable? %>
-  
+
 	<script type="text/javascript">
     $(function() {
       var uploader, container;
       container = $("#<%= field.id %> div.uploader-files");
-      
+
       $('#<%= field.id %> input[type="file"]').each(function(){
         $(this).fileupload({
           dataType: 'json',
@@ -36,10 +36,10 @@
           formData: function(form){ return []; },
           filesContainer: container,
           namespace: 'uploader',
-          uploadTemplateId: 'template-upload-<%= field.klass %>',
-          downloadTemplateId: 'template-download-<%= field.klass %>'
+          uploadTemplateId: 'template-upload-<%= "#{field.klass}-#{field.id}" %>',
+          downloadTemplateId: 'template-download-<%= "#{field.klass}-#{field.id}" %>'
         });
-        
+
         <% if field.exists? -%>
           uploader = ($(this).data('blueimp-fileupload') || $(this).data('fileupload'));
           uploader

--- a/app/views/uploader/default/_download.html.erb
+++ b/app/views/uploader/default/_download.html.erb
@@ -1,5 +1,5 @@
 <!-- The template to display files available for download -->
-<script id="template-download-<%= field.klass %>" type="text/x-tmpl">
+<script id="template-download-<%= "#{field.klass}-#{field.id}" %>" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
   <div id="asset_{%=file.id%}" class="attach_item template-download">
     <div class="buttons-panel">

--- a/app/views/uploader/default/_upload.html.erb
+++ b/app/views/uploader/default/_upload.html.erb
@@ -1,5 +1,5 @@
 <!-- The template to display files available for upload -->
-<script id="template-upload-<%= field.klass %>" type="text/x-tmpl">
+<script id="template-upload-<%= "#{field.klass}-#{field.id}" %>" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
   <div class="attach_item loading template-upload">
 		<div class="buttons-panel"><a href="#" class="del_btn cancel"></a></div>


### PR DESCRIPTION
In nested forms, this: `<script id="template-download-<%= field.klass %>" type="text/x-tmpl">` results in duplicated IDs.
It produces the same input IDs inside all nested forms.
e.g. `competition[participants_attributes][0][participant_images_attributes][181][title]` (all forms get the same 0 between [participants_attributes][ _and_ ][participant_images_attributes]).

I appended field.id to it: `template-download-<%= "#{field.klass}-#{field.id}" %>`.
Now every nested form would get separate x-tmpl with unique ID.